### PR TITLE
✨ add macos support for test project conditions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,7 @@
     <IsSourceProject>$(MSBuildProjectDirectory.ToLower().StartsWith('$(MSBuildThisFileDirectory.ToLower())src'))</IsSourceProject>
     <IsToolingProject>$(MSBuildProjectDirectory.ToLower().StartsWith('$(MSBuildThisFileDirectory.ToLower())tooling'))</IsToolingProject>
     <IsLinux>$([MSBuild]::IsOSPlatform('Linux'))</IsLinux>
+    <IsMacOS>$([MSBuild]::IsOSPlatform('OSX'))</IsMacOS>
     <IsWindows>$([MSBuild]::IsOSPlatform('Windows'))</IsWindows>
     <IsMainAuthor Condition="'$(EMAIL)' == 'michael@geekle.io'">true</IsMainAuthor>
     <SkipSignAssembly>false</SkipSignAssembly>
@@ -56,7 +57,7 @@
     <None Include="..\..\.nuget\$(MSBuildProjectName)\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(IsTestProject)' == 'true' AND '$(IsLinux)' == 'true'">
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true' AND ('$(IsLinux)' == 'true' OR '$(IsMacOS)' == 'true')">
     <TargetFrameworks>net10.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
This pull request updates the build configuration to improve platform detection and test project targeting. The main changes are the addition of a property to detect macOS and updating test project conditions to include macOS alongside Linux.

Platform detection improvements:

* Added a new `IsMacOS` property in `Directory.Build.props` to detect when the build is running on macOS.

Test project framework targeting:

* Updated the test project property group condition in `Directory.Build.props` so that projects on both Linux and macOS use the same target frameworks (`net10.0;net9.0`).