### PR TITLE
🩹 Fix macOS compatibility and adjust test timing for reliability

### DIFF
--- a/test/Cuemon.Core.Tests/Assets/UnmanagedDisposable.cs
+++ b/test/Cuemon.Core.Tests/Assets/UnmanagedDisposable.cs
@@ -48,7 +48,8 @@ namespace Cuemon.Assets
             }
             else if (Environment.OSVersion.Platform == PlatformID.Unix)
             {
-                if (NativeLibrary.TryLoad("libc.so.6", GetType().Assembly, DllImportSearchPath.SafeDirectories, out _libHandle))
+                var libraryName = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "libSystem.B.dylib" : "libc.so.6";
+                if (NativeLibrary.TryLoad(libraryName, GetType().Assembly, DllImportSearchPath.SafeDirectories, out _libHandle))
                 {
                     _handle = _libHandle; // i don't know of any native methods on unix
                 }

--- a/test/Cuemon.Diagnostics.Tests/TimeMeasureTest.cs
+++ b/test/Cuemon.Diagnostics.Tests/TimeMeasureTest.cs
@@ -11,7 +11,7 @@ namespace Cuemon.Diagnostics
     public class TimeMeasureTest : Test
     {
         private static readonly TimeSpan ExpectedExecutionTime = TimeSpan.FromSeconds(1);
-        private static readonly TimeSpan Jitter = TimeSpan.FromMilliseconds(100);
+        private static readonly TimeSpan Jitter = TimeSpan.FromMilliseconds(250);
 
         public TimeMeasureTest(ITestOutputHelper output) : base(output)
         {

--- a/test/Cuemon.Resilience.Tests/Assets/ActionTransientOperation.cs
+++ b/test/Cuemon.Resilience.Tests/Assets/ActionTransientOperation.cs
@@ -26,7 +26,7 @@ namespace Cuemon.Resilience.Assets
 
         public static void TriggerLatencyException(Guid id, ConcurrentDictionary<Guid, int> retryTracker)
         {
-            Thread.Sleep(250);
+            Thread.Sleep(750);
             retryTracker[id] += 1;
             throw new HttpRequestException();
         }

--- a/test/Cuemon.Resilience.Tests/Assets/AsyncActionTransientOperation.cs
+++ b/test/Cuemon.Resilience.Tests/Assets/AsyncActionTransientOperation.cs
@@ -29,7 +29,7 @@ namespace Cuemon.Resilience.Assets
 
         public static Task TriggerLatencyExceptionAsync(Guid id, ConcurrentDictionary<Guid, int> retryTracker, CancellationToken ct)
         {
-            Thread.Sleep(250);
+            Thread.Sleep(750);
             retryTracker[id] += 1;
             throw new HttpRequestException();
         }

--- a/test/Cuemon.Resilience.Tests/Assets/AsyncActionTransientOperation.cs
+++ b/test/Cuemon.Resilience.Tests/Assets/AsyncActionTransientOperation.cs
@@ -27,9 +27,9 @@ namespace Cuemon.Resilience.Assets
             throw new HttpRequestException();
         }
 
-        public static Task TriggerLatencyExceptionAsync(Guid id, ConcurrentDictionary<Guid, int> retryTracker, CancellationToken ct)
+        public static async Task TriggerLatencyExceptionAsync(Guid id, ConcurrentDictionary<Guid, int> retryTracker, CancellationToken ct)
         {
-            Thread.Sleep(750);
+            await Task.Delay(750, ct);
             retryTracker[id] += 1;
             throw new HttpRequestException();
         }

--- a/test/Cuemon.Resilience.Tests/Assets/AsyncFuncTransientOperation.cs
+++ b/test/Cuemon.Resilience.Tests/Assets/AsyncFuncTransientOperation.cs
@@ -27,9 +27,9 @@ namespace Cuemon.Resilience.Assets
             throw new HttpRequestException();
         }
 
-        public static Task<string> TriggerLatencyExceptionAsync(Guid id, ConcurrentDictionary<Guid, int> retryTracker, CancellationToken ct)
+        public static async Task<string> TriggerLatencyExceptionAsync(Guid id, ConcurrentDictionary<Guid, int> retryTracker, CancellationToken ct)
         {
-            Thread.Sleep(750);
+            await Task.Delay(750, ct);
             retryTracker[id] += 1;
             throw new HttpRequestException();
         }

--- a/test/Cuemon.Resilience.Tests/Assets/AsyncFuncTransientOperation.cs
+++ b/test/Cuemon.Resilience.Tests/Assets/AsyncFuncTransientOperation.cs
@@ -29,7 +29,7 @@ namespace Cuemon.Resilience.Assets
 
         public static Task<string> TriggerLatencyExceptionAsync(Guid id, ConcurrentDictionary<Guid, int> retryTracker, CancellationToken ct)
         {
-            Thread.Sleep(350);
+            Thread.Sleep(750);
             retryTracker[id] += 1;
             throw new HttpRequestException();
         }

--- a/test/Cuemon.Resilience.Tests/Assets/FuncTransientOperation.cs
+++ b/test/Cuemon.Resilience.Tests/Assets/FuncTransientOperation.cs
@@ -28,7 +28,7 @@ namespace Cuemon.Resilience.Assets
 
         public static string TriggerLatencyException(Guid id, ConcurrentDictionary<Guid, int> retryTracker)
         {
-            Thread.Sleep(250);
+            Thread.Sleep(750);
             retryTracker[id] += 1;
             throw new HttpRequestException();
         }

--- a/test/Cuemon.Resilience.Tests/TransientOperationTest.cs
+++ b/test/Cuemon.Resilience.Tests/TransientOperationTest.cs
@@ -21,7 +21,7 @@ namespace Cuemon.Resilience
         private const int NormalRunIncrement = 1;
         private const int DescriptiveExceptionCauseIncrement = 1;
         private static readonly TimeSpan ExpectedRecoveryWaitTime = TimeSpan.FromSeconds(1);
-        private static readonly TimeSpan ExpectedMaximumAllowedLatency = TimeSpan.FromMilliseconds(250);
+        private static readonly TimeSpan ExpectedMaximumAllowedLatency = TimeSpan.FromMilliseconds(500);
 
         public TransientOperationTest(ITestOutputHelper output) : base(output)
         {


### PR DESCRIPTION
This pull request adjusts test timing and platform compatibility in several test files. The main changes are increased latency and jitter values in resilience and diagnostics test cases to better accommodate timing variability, and improved cross-platform support for native library loading on Unix systems.

**Test timing adjustments:**

* Increased the jitter buffer in `TimeMeasureTest` from 100ms to 250ms to allow for more timing variability in test execution.
* Increased the expected maximum allowed latency in `TransientOperationTest` from 250ms to 500ms, making the test more tolerant to delays.
* Increased latency in the following transient operation test methods from 250–350ms to 750ms to simulate longer fault scenarios:
  - `TriggerLatencyException` in `ActionTransientOperation.cs`
  - `TriggerLatencyExceptionAsync` in `AsyncActionTransientOperation.cs`
  - `TriggerLatencyExceptionAsync` in `AsyncFuncTransientOperation.cs`
  - `TriggerLatencyException` in `FuncTransientOperation.cs`

**Platform compatibility improvements:**

* Updated native library loading in `UnmanagedDisposable` to use `libSystem.B.dylib` on macOS and `libc.so.6` on Linux, improving cross-platform support for Unix-based systems.