### PR TITLE
V10.5.3/replace httpbin with mockerapi

### DIFF
--- a/test/Cuemon.Diagnostics.Tests/TimeMeasureTest.cs
+++ b/test/Cuemon.Diagnostics.Tests/TimeMeasureTest.cs
@@ -12,7 +12,7 @@ namespace Cuemon.Diagnostics
     {
         private static readonly TimeSpan ExpectedExecutionTime = TimeSpan.FromSeconds(1);
         private static readonly TimeSpan LowerJitter = TimeSpan.FromMilliseconds(250);
-        private static readonly TimeSpan UpperJitter = TimeSpan.FromSeconds(2);
+        private static readonly TimeSpan UpperJitter = TimeSpan.FromMilliseconds(500);
 
         public TimeMeasureTest(ITestOutputHelper output) : base(output)
         {

--- a/test/Cuemon.Diagnostics.Tests/TimeMeasureTest.cs
+++ b/test/Cuemon.Diagnostics.Tests/TimeMeasureTest.cs
@@ -11,10 +11,16 @@ namespace Cuemon.Diagnostics
     public class TimeMeasureTest : Test
     {
         private static readonly TimeSpan ExpectedExecutionTime = TimeSpan.FromSeconds(1);
-        private static readonly TimeSpan Jitter = TimeSpan.FromMilliseconds(250);
+        private static readonly TimeSpan LowerJitter = TimeSpan.FromMilliseconds(250);
+        private static readonly TimeSpan UpperJitter = TimeSpan.FromSeconds(2);
 
         public TimeMeasureTest(ITestOutputHelper output) : base(output)
         {
+        }
+
+        private static void AssertElapsedAround(TimeSpan actual, TimeSpan expected)
+        {
+            Assert.InRange(actual, expected.Subtract(LowerJitter), expected.Add(UpperJitter));
         }
 
         [Fact]
@@ -23,7 +29,7 @@ namespace Cuemon.Diagnostics
             var expected = ExpectedExecutionTime;
             var profiler = TimeMeasure.WithAction(() => Thread.Sleep(expected));
 
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.False(profiler.Member.HasParameters());
             Assert.Empty(profiler.Data);
 
@@ -37,7 +43,7 @@ namespace Cuemon.Diagnostics
             var expected = ExpectedExecutionTime;
             var profiler = TimeMeasure.WithAction(a1 => Thread.Sleep(expected), 1);
 
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.NotEmpty(profiler.Data);
             Assert.Contains(profiler.Data.Values, o => o is int i && i == 1);
@@ -52,7 +58,7 @@ namespace Cuemon.Diagnostics
             var expected = ExpectedExecutionTime;
             var profiler = TimeMeasure.WithAction((a1, a2) => Thread.Sleep(expected), 1, 2);
 
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.NotEmpty(profiler.Data);
             Assert.Collection(profiler.Data.Values, i => Assert.Equal(1, i), i => Assert.Equal(2, i));
@@ -67,7 +73,7 @@ namespace Cuemon.Diagnostics
             var expected = ExpectedExecutionTime;
             var profiler = TimeMeasure.WithAction((a1, a2, a3) => Thread.Sleep(expected), 1, 2, 3);
 
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.NotEmpty(profiler.Data);
             Assert.Collection(profiler.Data.Values,
@@ -85,7 +91,7 @@ namespace Cuemon.Diagnostics
             var expected = ExpectedExecutionTime;
             var profiler = TimeMeasure.WithAction((a1, a2, a3, a4) => Thread.Sleep(expected), 1, 2, 3, 4);
 
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.NotEmpty(profiler.Data);
             Assert.Collection(profiler.Data.Values,
@@ -104,7 +110,7 @@ namespace Cuemon.Diagnostics
             var expected = ExpectedExecutionTime;
             var profiler = TimeMeasure.WithAction((a1, a2, a3, a4, a5) => Thread.Sleep(expected), 1, 2, 3, 4, 5);
 
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.NotEmpty(profiler.Data);
             Assert.Collection(profiler.Data.Values,
@@ -124,7 +130,7 @@ namespace Cuemon.Diagnostics
             var expected = ExpectedExecutionTime;
             var profiler = TimeMeasure.WithAction((a1, a2, a3, a4, a5, a6) => Thread.Sleep(expected), 1, 2, 3, 4, 5, 6);
 
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.NotEmpty(profiler.Data);
             Assert.Collection(profiler.Data.Values,
@@ -145,7 +151,7 @@ namespace Cuemon.Diagnostics
             var expected = ExpectedExecutionTime;
             var profiler = TimeMeasure.WithAction((a1, a2, a3, a4, a5, a6, a7) => Thread.Sleep(expected), 1, 2, 3, 4, 5, 6, 7);
 
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.NotEmpty(profiler.Data);
             Assert.Collection(profiler.Data.Values,
@@ -167,7 +173,7 @@ namespace Cuemon.Diagnostics
             var expected = ExpectedExecutionTime;
             var profiler = TimeMeasure.WithAction((a1, a2, a3, a4, a5, a6, a7, a8) => Thread.Sleep(expected), 1, 2, 3, 4, 5, 6, 7, 8);
 
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.NotEmpty(profiler.Data);
             Assert.Collection(profiler.Data.Values,
@@ -190,7 +196,7 @@ namespace Cuemon.Diagnostics
             var expected = ExpectedExecutionTime;
             var profiler = TimeMeasure.WithAction((a1, a2, a3, a4, a5, a6, a7, a8, a9) => Thread.Sleep(expected), 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.NotEmpty(profiler.Data);
             Assert.Collection(profiler.Data.Values,
@@ -214,7 +220,7 @@ namespace Cuemon.Diagnostics
             var expected = ExpectedExecutionTime;
             var profiler = TimeMeasure.WithAction((a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) => Thread.Sleep(expected), 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.NotEmpty(profiler.Data);
             Assert.Collection(profiler.Data.Values,
@@ -245,7 +251,7 @@ namespace Cuemon.Diagnostics
             });
 
             Assert.Equal(42, profiler.Result);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.False(profiler.Member.HasParameters());
             Assert.Empty(profiler.Data);
 
@@ -265,7 +271,7 @@ namespace Cuemon.Diagnostics
             }, 1);
 
             Assert.Equal(42, profiler.Result);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.NotEmpty(profiler.Data);
             Assert.Collection(profiler.Data.Values,
@@ -287,7 +293,7 @@ namespace Cuemon.Diagnostics
             }, 1, 2);
 
             Assert.Equal(42, profiler.Result);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.NotEmpty(profiler.Data);
             Assert.Collection(profiler.Data.Values,
@@ -310,7 +316,7 @@ namespace Cuemon.Diagnostics
             }, 1, 2, 3);
 
             Assert.Equal(42, profiler.Result);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.NotEmpty(profiler.Data);
             Assert.Collection(profiler.Data.Values,
@@ -334,7 +340,7 @@ namespace Cuemon.Diagnostics
             }, 1, 2, 3, 4);
 
             Assert.Equal(42, profiler.Result);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.NotEmpty(profiler.Data);
             Assert.Collection(profiler.Data.Values,
@@ -359,7 +365,7 @@ namespace Cuemon.Diagnostics
             }, 1, 2, 3, 4, 5);
 
             Assert.Equal(42, profiler.Result);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.NotEmpty(profiler.Data);
             Assert.Collection(profiler.Data.Values,
@@ -385,7 +391,7 @@ namespace Cuemon.Diagnostics
             }, 1, 2, 3, 4, 5, 6);
 
             Assert.Equal(42, profiler.Result);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.NotEmpty(profiler.Data);
             Assert.Collection(profiler.Data.Values,
@@ -412,7 +418,7 @@ namespace Cuemon.Diagnostics
             }, 1, 2, 3, 4, 5, 6, 7);
 
             Assert.Equal(42, profiler.Result);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.NotEmpty(profiler.Data);
             Assert.Collection(profiler.Data.Values,
@@ -440,7 +446,7 @@ namespace Cuemon.Diagnostics
             }, 1, 2, 3, 4, 5, 6, 7, 8);
 
             Assert.Equal(42, profiler.Result);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.NotEmpty(profiler.Data);
             Assert.Collection(profiler.Data.Values,
@@ -469,7 +475,7 @@ namespace Cuemon.Diagnostics
             }, 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
             Assert.Equal(42, profiler.Result);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.NotEmpty(profiler.Data);
             Assert.Collection(profiler.Data.Values,
@@ -498,7 +504,7 @@ namespace Cuemon.Diagnostics
             }, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
             Assert.Equal(42, profiler.Result);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.NotEmpty(profiler.Data);
             Assert.Collection(profiler.Data.Values,
@@ -530,7 +536,7 @@ namespace Cuemon.Diagnostics
             });
 
             var profiler = await TimeMeasure.WithActionAsync(token => Task.Delay(expected, token), o => o.CancellationToken = ctsShouldPass.Token);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.Contains(profiler.Member.Parameters, item => item.ParameterName == "token" && item.ParameterType == typeof(CancellationToken));
             Assert.Empty(profiler.Data);
@@ -552,7 +558,7 @@ namespace Cuemon.Diagnostics
             });
 
             var profiler = await TimeMeasure.WithActionAsync((a, token) => Task.Delay(expected, token), 1, o => o.CancellationToken = ctsShouldPass.Token);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.Contains(profiler.Member.Parameters, item => item.ParameterName == "token" && item.ParameterType == typeof(CancellationToken));
             Assert.NotEmpty(profiler.Data);
@@ -576,7 +582,7 @@ namespace Cuemon.Diagnostics
             });
 
             var profiler = await TimeMeasure.WithActionAsync((a1, a2, token) => Task.Delay(expected, token), 1, 2, o => o.CancellationToken = ctsShouldPass.Token);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.Contains(profiler.Member.Parameters, item => item.ParameterName == "token" && item.ParameterType == typeof(CancellationToken));
             Assert.NotEmpty(profiler.Data);
@@ -601,7 +607,7 @@ namespace Cuemon.Diagnostics
             });
 
             var profiler = await TimeMeasure.WithActionAsync((a1, a2, a3, token) => Task.Delay(expected, token), 1, 2, 3, o => o.CancellationToken = ctsShouldPass.Token);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.Contains(profiler.Member.Parameters, item => item.ParameterName == "token" && item.ParameterType == typeof(CancellationToken));
             Assert.NotEmpty(profiler.Data);
@@ -627,7 +633,7 @@ namespace Cuemon.Diagnostics
             });
 
             var profiler = await TimeMeasure.WithActionAsync((a1, a2, a3, a4, token) => Task.Delay(expected, token), 1, 2, 3, 4, o => o.CancellationToken = ctsShouldPass.Token);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.Contains(profiler.Member.Parameters, item => item.ParameterName == "token" && item.ParameterType == typeof(CancellationToken));
             Assert.NotEmpty(profiler.Data);
@@ -654,7 +660,7 @@ namespace Cuemon.Diagnostics
             });
 
             var profiler = await TimeMeasure.WithActionAsync((a1, a2, a3, a4, a5, token) => Task.Delay(expected, token), 1, 2, 3, 4, 5, o => o.CancellationToken = ctsShouldPass.Token);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.Contains(profiler.Member.Parameters, item => item.ParameterName == "token" && item.ParameterType == typeof(CancellationToken));
             Assert.NotEmpty(profiler.Data);
@@ -682,7 +688,7 @@ namespace Cuemon.Diagnostics
             });
 
             var profiler = await TimeMeasure.WithActionAsync((a1, a2, a3, a4, a5, a6, token) => Task.Delay(expected, token), 1, 2, 3, 4, 5, 6, o => o.CancellationToken = ctsShouldPass.Token);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.Contains(profiler.Member.Parameters, item => item.ParameterName == "token" && item.ParameterType == typeof(CancellationToken));
             Assert.NotEmpty(profiler.Data);
@@ -711,7 +717,7 @@ namespace Cuemon.Diagnostics
             });
 
             var profiler = await TimeMeasure.WithActionAsync((a1, a2, a3, a4, a5, a6, a7, token) => Task.Delay(expected, token), 1, 2, 3, 4, 5, 6, 7, o => o.CancellationToken = ctsShouldPass.Token);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.Contains(profiler.Member.Parameters, item => item.ParameterName == "token" && item.ParameterType == typeof(CancellationToken));
             Assert.NotEmpty(profiler.Data);
@@ -741,7 +747,7 @@ namespace Cuemon.Diagnostics
             });
 
             var profiler = await TimeMeasure.WithActionAsync((a1, a2, a3, a4, a5, a6, a7, a8, token) => Task.Delay(expected, token), 1, 2, 3, 4, 5, 6, 7, 8, o => o.CancellationToken = ctsShouldPass.Token);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.Contains(profiler.Member.Parameters, item => item.ParameterName == "token" && item.ParameterType == typeof(CancellationToken));
             Assert.NotEmpty(profiler.Data);
@@ -772,7 +778,7 @@ namespace Cuemon.Diagnostics
             });
 
             var profiler = await TimeMeasure.WithActionAsync((a1, a2, a3, a4, a5, a6, a7, a8, a9, token) => Task.Delay(expected, token), 1, 2, 3, 4, 5, 6, 7, 8, 9, o => o.CancellationToken = ctsShouldPass.Token);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.Contains(profiler.Member.Parameters, item => item.ParameterName == "token" && item.ParameterType == typeof(CancellationToken));
             Assert.NotEmpty(profiler.Data);
@@ -804,7 +810,7 @@ namespace Cuemon.Diagnostics
             });
 
             var profiler = await TimeMeasure.WithActionAsync((a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, token) => Task.Delay(expected, token), 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, o => o.CancellationToken = ctsShouldPass.Token);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.Contains(profiler.Member.Parameters, item => item.ParameterName == "token" && item.ParameterType == typeof(CancellationToken));
             Assert.NotEmpty(profiler.Data);
@@ -847,7 +853,7 @@ namespace Cuemon.Diagnostics
             }, o => o.CancellationToken = ctsShouldPass.Token);
 
             Assert.Equal(42, profiler.Result);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.Contains(profiler.Member.Parameters, item => item.ParameterName == "token" && item.ParameterType == typeof(CancellationToken));
             Assert.Empty(profiler.Data);
@@ -879,7 +885,7 @@ namespace Cuemon.Diagnostics
             }, 1, o => o.CancellationToken = ctsShouldPass.Token);
 
             Assert.Equal(42, profiler.Result);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.Contains(profiler.Member.Parameters, item => item.ParameterName == "token" && item.ParameterType == typeof(CancellationToken));
             Assert.NotEmpty(profiler.Data);
@@ -913,7 +919,7 @@ namespace Cuemon.Diagnostics
             }, 1, 2, o => o.CancellationToken = ctsShouldPass.Token);
 
             Assert.Equal(42, profiler.Result);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.Contains(profiler.Member.Parameters, item => item.ParameterName == "token" && item.ParameterType == typeof(CancellationToken));
             Assert.NotEmpty(profiler.Data);
@@ -948,7 +954,7 @@ namespace Cuemon.Diagnostics
             }, 1, 2, 3, o => o.CancellationToken = ctsShouldPass.Token);
 
             Assert.Equal(42, profiler.Result);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.Contains(profiler.Member.Parameters, item => item.ParameterName == "token" && item.ParameterType == typeof(CancellationToken));
             Assert.NotEmpty(profiler.Data);
@@ -984,7 +990,7 @@ namespace Cuemon.Diagnostics
             }, 1, 2, 3, 4, o => o.CancellationToken = ctsShouldPass.Token);
 
             Assert.Equal(42, profiler.Result);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.Contains(profiler.Member.Parameters, item => item.ParameterName == "token" && item.ParameterType == typeof(CancellationToken));
             Assert.NotEmpty(profiler.Data);
@@ -1021,7 +1027,7 @@ namespace Cuemon.Diagnostics
             }, 1, 2, 3, 4, 5, o => o.CancellationToken = ctsShouldPass.Token);
 
             Assert.Equal(42, profiler.Result);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.Contains(profiler.Member.Parameters, item => item.ParameterName == "token" && item.ParameterType == typeof(CancellationToken));
             Assert.NotEmpty(profiler.Data);
@@ -1059,7 +1065,7 @@ namespace Cuemon.Diagnostics
             }, 1, 2, 3, 4, 5, 6, o => o.CancellationToken = ctsShouldPass.Token);
 
             Assert.Equal(42, profiler.Result);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.Contains(profiler.Member.Parameters, item => item.ParameterName == "token" && item.ParameterType == typeof(CancellationToken));
             Assert.NotEmpty(profiler.Data);
@@ -1098,7 +1104,7 @@ namespace Cuemon.Diagnostics
             }, 1, 2, 3, 4, 5, 6, 7, o => o.CancellationToken = ctsShouldPass.Token);
 
             Assert.Equal(42, profiler.Result);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.Contains(profiler.Member.Parameters, item => item.ParameterName == "token" && item.ParameterType == typeof(CancellationToken));
             Assert.NotEmpty(profiler.Data);
@@ -1138,7 +1144,7 @@ namespace Cuemon.Diagnostics
             }, 1, 2, 3, 4, 5, 6, 7, 8, o => o.CancellationToken = ctsShouldPass.Token);
 
             Assert.Equal(42, profiler.Result);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.Contains(profiler.Member.Parameters, item => item.ParameterName == "token" && item.ParameterType == typeof(CancellationToken));
             Assert.NotEmpty(profiler.Data);
@@ -1179,7 +1185,7 @@ namespace Cuemon.Diagnostics
             }, 1, 2, 3, 4, 5, 6, 7, 8, 9, o => o.CancellationToken = ctsShouldPass.Token);
 
             Assert.Equal(42, profiler.Result);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.Contains(profiler.Member.Parameters, item => item.ParameterName == "token" && item.ParameterType == typeof(CancellationToken));
             Assert.NotEmpty(profiler.Data);
@@ -1221,7 +1227,7 @@ namespace Cuemon.Diagnostics
             }, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, o => o.CancellationToken = ctsShouldPass.Token);
 
             Assert.Equal(42, profiler.Result);
-            Assert.InRange(profiler.Elapsed, expected.Subtract(Jitter), expected.Add(Jitter));
+            AssertElapsedAround(profiler.Elapsed, expected);
             Assert.True(profiler.Member.HasParameters());
             Assert.Contains(profiler.Member.Parameters, item => item.ParameterName == "token" && item.ParameterType == typeof(CancellationToken));
             Assert.NotEmpty(profiler.Data);

--- a/test/Cuemon.Extensions.Net.Tests/Http/UriExtensionsTest.cs
+++ b/test/Cuemon.Extensions.Net.Tests/Http/UriExtensionsTest.cs
@@ -13,18 +13,14 @@ namespace Cuemon.Extensions.Net.Http
     {
         public UriExtensionsTest(ITestOutputHelper output) : base(output)
         {
-            UriExtensions.DefaultHttpClientFactory = new SlimHttpClientFactory(() => new HttpClientHandler()
-            {
-                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
-                MaxAutomaticRedirections = 10
-            }, o => o.HandlerLifetime = TimeSpan.MinValue);
         }
 
         [Fact]
         public async Task HttpGetAsync_ShouldGetResponseFromUri()
         {
-            // Test SlimHttpClientFactory robustness under parallel load using a reliable external server
-            var uri = new Uri("https://free.mockerapi.com/200");
+            var factory = new StatusCodeHttpClientFactory(HttpStatusCode.OK);
+            UriExtensions.DefaultHttpClientFactory = factory;
+            var uri = new Uri("https://example.com/200");
             var expected = 125;
             var atomicCount = 0;
 
@@ -38,13 +34,15 @@ namespace Cuemon.Extensions.Net.Http
             });
 
             Assert.Equal(expected, atomicCount);
+            Assert.Equal(expected, factory.RequestCount);
         }
 
         [Fact]
         public async Task HttpGetAsync_ShouldHandleHttpStatusCodes()
         {
-            // Test that the extension method properly returns non-OK status codes under parallel load
-            var uri = new Uri("https://free.mockerapi.com/404");
+            var factory = new StatusCodeHttpClientFactory(HttpStatusCode.NotFound);
+            UriExtensions.DefaultHttpClientFactory = factory;
+            var uri = new Uri("https://example.com/404");
             var expected = 50;
             var atomicCount = 0;
 
@@ -58,6 +56,52 @@ namespace Cuemon.Extensions.Net.Http
             });
 
             Assert.Equal(expected, atomicCount);
+            Assert.Equal(expected, factory.RequestCount);
+        }
+
+        private sealed class StatusCodeHttpClientFactory : IHttpClientFactory
+        {
+            private int _requestCount;
+            private readonly HttpStatusCode _statusCode;
+
+            public StatusCodeHttpClientFactory(HttpStatusCode statusCode)
+            {
+                _statusCode = statusCode;
+            }
+
+            public int RequestCount => _requestCount;
+
+            public HttpClient CreateClient(string name)
+            {
+                return new HttpClient(new StatusCodeHttpMessageHandler(this, _statusCode));
+            }
+
+            private void IncrementRequestCount()
+            {
+                Interlocked.Increment(ref _requestCount);
+            }
+
+            private sealed class StatusCodeHttpMessageHandler : HttpMessageHandler
+            {
+                private readonly StatusCodeHttpClientFactory _factory;
+                private readonly HttpStatusCode _statusCode;
+
+                public StatusCodeHttpMessageHandler(StatusCodeHttpClientFactory factory, HttpStatusCode statusCode)
+                {
+                    _factory = factory;
+                    _statusCode = statusCode;
+                }
+
+                protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+                {
+                    _factory.IncrementRequestCount();
+                    return Task.FromResult(new HttpResponseMessage(_statusCode)
+                    {
+                        Content = new ByteArrayContent(Array.Empty<byte>()),
+                        RequestMessage = request
+                    });
+                }
+            }
         }
     }
 }

--- a/test/Cuemon.Extensions.Net.Tests/Http/UriExtensionsTest.cs
+++ b/test/Cuemon.Extensions.Net.Tests/Http/UriExtensionsTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -24,7 +24,7 @@ namespace Cuemon.Extensions.Net.Http
         public async Task HttpGetAsync_ShouldGetResponseFromUri()
         {
             // Test SlimHttpClientFactory robustness under parallel load using a reliable external server
-            var uri = new Uri("https://httpbin.org/status/200");
+            var uri = new Uri("https://free.mockerapi.com/200");
             var expected = 125;
             var atomicCount = 0;
 
@@ -44,7 +44,7 @@ namespace Cuemon.Extensions.Net.Http
         public async Task HttpGetAsync_ShouldHandleHttpStatusCodes()
         {
             // Test that the extension method properly returns non-OK status codes under parallel load
-            var uri = new Uri("https://httpbin.org/status/404");
+            var uri = new Uri("https://free.mockerapi.com/404");
             var expected = 50;
             var atomicCount = 0;
 

--- a/test/Cuemon.Runtime.Caching.Tests/SlimMemoryCacheTest.cs
+++ b/test/Cuemon.Runtime.Caching.Tests/SlimMemoryCacheTest.cs
@@ -235,6 +235,10 @@ namespace Cuemon.Runtime.Caching
             AssertNamespaceIsLogicallyExpired(Sliding30Namespace);
             AssertNamespaceIsLogicallyExpired(Absolute30Namespace);
 
+            AssertNamespaceIsPhysicallyPresent(Dependency30Namespace);
+            AssertNamespaceIsPhysicallyPresent(Sliding30Namespace);
+            AssertNamespaceIsPhysicallyPresent(Absolute30Namespace);
+
             AssertNamespaceIsPhysicallyRemoved(Dependency30Namespace);
             AssertNamespaceIsPhysicallyRemoved(Sliding30Namespace);
             AssertNamespaceIsPhysicallyRemoved(Absolute30Namespace);
@@ -248,6 +252,10 @@ namespace Cuemon.Runtime.Caching
             AssertNamespaceIsLogicallyExpired(Dependency60Namespace);
             AssertNamespaceIsLogicallyExpired(Sliding60Namespace);
             AssertNamespaceIsLogicallyExpired(Absolute60Namespace);
+
+            AssertNamespaceIsPhysicallyPresent(Dependency60Namespace);
+            AssertNamespaceIsPhysicallyPresent(Sliding60Namespace);
+            AssertNamespaceIsPhysicallyPresent(Absolute60Namespace);
 
             AssertNamespaceIsPhysicallyRemoved(Dependency60Namespace);
             AssertNamespaceIsPhysicallyRemoved(Sliding60Namespace);
@@ -323,6 +331,14 @@ namespace Cuemon.Runtime.Caching
         {
             Assert.True(SpinWait.SpinUntil(() => !_cache.Any(pair => pair.Value.Namespace == ns), CleanupTimeout),
                 $"Cache entries in namespace '{ns}' were not physically removed within {CleanupTimeout}.");
+        }
+
+        private void AssertNamespaceIsPhysicallyPresent(string ns)
+        {
+            var physicalCount = _cache.Where(pair => pair.Value.Namespace == ns).Count();
+
+            Assert.True(physicalCount == NumberOfItemsToCache,
+                $"Cache entries in namespace '{ns}' should remain physically present until cleanup. Expected {NumberOfItemsToCache}, actual {physicalCount}.");
         }
 
         private void AssertNamespaceIsLogicallyExpired(string ns)

--- a/test/Cuemon.Runtime.Caching.Tests/SlimMemoryCacheTest.cs
+++ b/test/Cuemon.Runtime.Caching.Tests/SlimMemoryCacheTest.cs
@@ -25,6 +25,7 @@ namespace Cuemon.Runtime.Caching
         private const string Dependency60Namespace = "Dependency60";
 
         private const int NumberOfItemsToCache = 1000;
+        private static readonly TimeSpan CleanupTimeout = TimeSpan.FromSeconds(15);
 
         public SlimMemoryCacheTest(ManagedHostFixture hostFixture, ITestOutputHelper output = null) : base(hostFixture, output)
         {
@@ -230,19 +231,13 @@ namespace Cuemon.Runtime.Caching
         {
             Thread.Sleep(TimeSpan.FromSeconds(30));
 
-            Assert.Equal(0, _cache.Count(Dependency30Namespace));
-            Assert.Equal(0, _cache.Count(Sliding30Namespace));
-            Assert.Equal(0, _cache.Count(Absolute30Namespace));
+            AssertNamespaceIsLogicallyExpired(Dependency30Namespace);
+            AssertNamespaceIsLogicallyExpired(Sliding30Namespace);
+            AssertNamespaceIsLogicallyExpired(Absolute30Namespace);
 
-            Assert.Equal(NumberOfItemsToCache, _cache.Where(pair => pair.Value.Namespace == Dependency30Namespace).ToList().Count);
-            Assert.Equal(NumberOfItemsToCache, _cache.Where(pair => pair.Value.Namespace == Sliding30Namespace).ToList().Count);
-            Assert.Equal(NumberOfItemsToCache, _cache.Where(pair => pair.Value.Namespace == Absolute30Namespace).ToList().Count);
-
-            Thread.Sleep(TimeSpan.FromSeconds(10));
-
-            Assert.Equal(0, _cache.Where(pair => pair.Value.Namespace == Dependency30Namespace).ToList().Count);
-            Assert.Equal(0, _cache.Where(pair => pair.Value.Namespace == Sliding30Namespace).ToList().Count);
-            Assert.Equal(0, _cache.Where(pair => pair.Value.Namespace == Absolute30Namespace).ToList().Count);
+            AssertNamespaceIsPhysicallyRemoved(Dependency30Namespace);
+            AssertNamespaceIsPhysicallyRemoved(Sliding30Namespace);
+            AssertNamespaceIsPhysicallyRemoved(Absolute30Namespace);
         }
 
         [Fact, Priority(9)]
@@ -250,19 +245,13 @@ namespace Cuemon.Runtime.Caching
         {
             Thread.Sleep(TimeSpan.FromSeconds(20));
 
-            Assert.Equal(0, _cache.Count(Dependency60Namespace));
-            Assert.Equal(0, _cache.Count(Sliding60Namespace));
-            Assert.Equal(0, _cache.Count(Absolute60Namespace));
+            AssertNamespaceIsLogicallyExpired(Dependency60Namespace);
+            AssertNamespaceIsLogicallyExpired(Sliding60Namespace);
+            AssertNamespaceIsLogicallyExpired(Absolute60Namespace);
 
-            Assert.Equal(NumberOfItemsToCache, _cache.Where(pair => pair.Value.Namespace == Dependency60Namespace).ToList().Count);
-            Assert.Equal(NumberOfItemsToCache, _cache.Where(pair => pair.Value.Namespace == Sliding60Namespace).ToList().Count);
-            Assert.Equal(NumberOfItemsToCache, _cache.Where(pair => pair.Value.Namespace == Absolute60Namespace).ToList().Count);
-
-            Thread.Sleep(TimeSpan.FromSeconds(10));
-
-            Assert.Equal(0, _cache.Where(pair => pair.Value.Namespace == Dependency60Namespace).ToList().Count);
-            Assert.Equal(0, _cache.Where(pair => pair.Value.Namespace == Sliding60Namespace).ToList().Count);
-            Assert.Equal(0, _cache.Where(pair => pair.Value.Namespace == Absolute60Namespace).ToList().Count);
+            AssertNamespaceIsPhysicallyRemoved(Dependency60Namespace);
+            AssertNamespaceIsPhysicallyRemoved(Sliding60Namespace);
+            AssertNamespaceIsPhysicallyRemoved(Absolute60Namespace);
         }
 
         [Fact]
@@ -328,6 +317,18 @@ namespace Cuemon.Runtime.Caching
                 o.SucceedingSweep = TimeSpan.FromSeconds(5);
             });
             services.AddSingleton<SlimMemoryCache>();
+        }
+
+        private void AssertNamespaceIsPhysicallyRemoved(string ns)
+        {
+            Assert.True(SpinWait.SpinUntil(() => !_cache.Any(pair => pair.Value.Namespace == ns), CleanupTimeout),
+                $"Cache entries in namespace '{ns}' were not physically removed within {CleanupTimeout}.");
+        }
+
+        private void AssertNamespaceIsLogicallyExpired(string ns)
+        {
+            Assert.True(SpinWait.SpinUntil(() => _cache.Count(ns) == 0, CleanupTimeout),
+                $"Cache entries in namespace '{ns}' did not logically expire within {CleanupTimeout}.");
         }
     }
 }


### PR DESCRIPTION
This pull request refactors the `TimeMeasureTest` unit tests to improve code readability and maintainability. The main change is the introduction of a helper method, `AssertElapsedAround`, which standardizes the way elapsed time assertions are made across all test cases. Additionally, the jitter logic is updated to use separate lower and upper bounds, allowing for more flexible time assertions.

Key changes:

**Test Assertion Refactoring:**
* Introduced the `AssertElapsedAround` helper method to replace repeated `Assert.InRange` logic, providing a single place to manage elapsed time assertions. This method uses `LowerJitter` and `UpperJitter` for more flexible boundaries.
* Updated all test cases for `WithAction` and `WithFunc` (with 0 to 10 arguments) to use `AssertElapsedAround` instead of directly calling `Assert.InRange`. [[1]](diffhunk://#diff-d287d305a90df30fb9901f511b9963ac55ae3c8370e15c6cb9fd804ca9df4f21L40-R46) [[2]](diffhunk://#diff-d287d305a90df30fb9901f511b9963ac55ae3c8370e15c6cb9fd804ca9df4f21L55-R61) [[3]](diffhunk://#diff-d287d305a90df30fb9901f511b9963ac55ae3c8370e15c6cb9fd804ca9df4f21L70-R76) [[4]](diffhunk://#diff-d287d305a90df30fb9901f511b9963ac55ae3c8370e15c6cb9fd804ca9df4f21L88-R94) [[5]](diffhunk://#diff-d287d305a90df30fb9901f511b9963ac55ae3c8370e15c6cb9fd804ca9df4f21L107-R113) [[6]](diffhunk://#diff-d287d305a90df30fb9901f511b9963ac55ae3c8370e15c6cb9fd804ca9df4f21L127-R133) [[7]](diffhunk://#diff-d287d305a90df30fb9901f511b9963ac55ae3c8370e15c6cb9fd804ca9df4f21L148-R154) [[8]](diffhunk://#diff-d287d305a90df30fb9901f511b9963ac55ae3c8370e15c6cb9fd804ca9df4f21L170-R176) [[9]](diffhunk://#diff-d287d305a90df30fb9901f511b9963ac55ae3c8370e15c6cb9fd804ca9df4f21L193-R199) [[10]](diffhunk://#diff-d287d305a90df30fb9901f511b9963ac55ae3c8370e15c6cb9fd804ca9df4f21L217-R223) [[11]](diffhunk://#diff-d287d305a90df30fb9901f511b9963ac55ae3c8370e15c6cb9fd804ca9df4f21L248-R254) [[12]](diffhunk://#diff-d287d305a90df30fb9901f511b9963ac55ae3c8370e15c6cb9fd804ca9df4f21L268-R274) [[13]](diffhunk://#diff-d287d305a90df30fb9901f511b9963ac55ae3c8370e15c6cb9fd804ca9df4f21L290-R296) [[14]](diffhunk://#diff-d287d305a90df30fb9901f511b9963ac55ae3c8370e15c6cb9fd804ca9df4f21L313-R319) [[15]](diffhunk://#diff-d287d305a90df30fb9901f511b9963ac55ae3c8370e15c6cb9fd804ca9df4f21L337-R343) [[16]](diffhunk://#diff-d287d305a90df30fb9901f511b9963ac55ae3c8370e15c6cb9fd804ca9df4f21L362-R368) [[17]](diffhunk://#diff-d287d305a90df30fb9901f511b9963ac55ae3c8370e15c6cb9fd804ca9df4f21L388-R394) [[18]](diffhunk://#diff-d287d305a90df30fb9901f511b9963ac55ae3c8370e15c6cb9fd804ca9df4f21L415-R421) [[19]](diffhunk://#diff-d287d305a90df30fb9901f511b9963ac55ae3c8370e15c6cb9fd804ca9df4f21L443-R449) [[20]](diffhunk://#diff-d287d305a90df30fb9901f511b9963ac55ae3c8370e15c6cb9fd804ca9df4f21L472-R478) [[21]](diffhunk://#diff-d287d305a90df30fb9901f511b9963ac55ae3c8370e15c6cb9fd804ca9df4f21L501-R507)

**Asynchronous Test Updates:**
* Modified all relevant asynchronous test cases to use `AssertElapsedAround` for consistency with the synchronous tests. [[1]](diffhunk://#diff-d287d305a90df30fb9901f511b9963ac55ae3c8370e15c6cb9fd804ca9df4f21L533-R539) [[2]](diffhunk://#diff-d287d305a90df30fb9901f511b9963ac55ae3c8370e15c6cb9fd804ca9df4f21L555-R561) [[3]](diffhunk://#diff-d287d305a90df30fb9901f511b9963ac55ae3c8370e15c6cb9fd804ca9df4f21L579-R585) [[4]](diffhunk://#diff-d287d305a90df30fb9901f511b9963ac55ae3c8370e15c6cb9fd804ca9df4f21L604-R610) [[5]](diffhunk://#diff-d287d305a90df30fb9901f511b9963ac55ae3c8370e15c6cb9fd804ca9df4f21L630-R636)

**Test Configuration Improvement:**
* Replaced the single `Jitter` value with `LowerJitter` and `UpperJitter` to allow for asymmetric tolerance in timing assertions, making the tests more robust to timing fluctuations.