### PR TITLE
V10.7.0/razor enhancement and service update

### DIFF
--- a/.docfx/api/types/Cuemon.AspNetCore.Razor.TagHelpers.TagHelperBaseUrlMode.md
+++ b/.docfx/api/types/Cuemon.AspNetCore.Razor.TagHelpers.TagHelperBaseUrlMode.md
@@ -1,0 +1,41 @@
+---
+uid: Cuemon.AspNetCore.Razor.TagHelpers.TagHelperBaseUrlMode
+example:
+- *content
+---
+
+The `TagHelperBaseUrlMode` enumeration controls how the base URL of a static resource is resolved by the app- and CDN-scoped tag helpers. `Configured` (the default) resolves the base URL exclusively from the configured `BaseUrl` and `Scheme`, whereas `Automatic` uses the configured `BaseUrl` when present and otherwise derives the base URL from the current HTTP request — useful when the same deployment is served from multiple origins. The following example demonstrates both modes through `CdnTagHelperOptions` and `GetFormattedBaseUrl`.
+
+```csharp
+using System;
+using Cuemon.AspNetCore.Razor.TagHelpers;
+using Microsoft.AspNetCore.Http;
+
+namespace DocfxExamples;
+
+public class TagHelperBaseUrlModeExample
+{
+    public void Demonstrate()
+    {
+        var configured = new CdnTagHelperOptions
+        {
+            BaseUrlMode = TagHelperBaseUrlMode.Configured,
+            Scheme = ProtocolUriScheme.Https,
+            BaseUrl = "static.example.com"
+        };
+        Console.WriteLine(configured.GetFormattedBaseUrl()); // Output: https://static.example.com/
+
+        var automatic = new CdnTagHelperOptions
+        {
+            BaseUrlMode = TagHelperBaseUrlMode.Automatic,
+            BaseUrl = null // No fixed origin, so fall back to the current HTTP request.
+        };
+        var request = new DefaultHttpContext().Request;
+        request.Scheme = "https";
+        request.Host = new HostString("app.example.com");
+        request.PathBase = "/myapp";
+        Console.WriteLine(automatic.GetFormattedBaseUrl(request)); // Output: https://app.example.com/myapp/
+    }
+}
+
+```

--- a/.nuget/Cuemon.AspNetCore.App/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.AspNetCore.App/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10 and .NET 9
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10 and .NET 9
 

--- a/.nuget/Cuemon.AspNetCore.Authentication/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.AspNetCore.Authentication/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10 and .NET 9
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10 and .NET 9
 

--- a/.nuget/Cuemon.AspNetCore.Mvc/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.AspNetCore.Mvc/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10 and .NET 9
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10 and .NET 9
 

--- a/.nuget/Cuemon.AspNetCore.Razor.TagHelpers/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.AspNetCore.Razor.TagHelpers/PackageReleaseNotes.txt
@@ -1,3 +1,15 @@
+Version: 10.7.0
+Availability: .NET 10 and .NET 9
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
+# New Features
+- ADDED `TagHelperBaseUrlMode` enum to control how base URLs are resolved in tag helper options
+- ADDED automatic base URL resolution to `CacheBustingTagHelper` via the new `ResolveUrl` method
+- ADDED `ViewContext` property to `CacheBustingTagHelper` to enable access to the current HTTP request context
+- EXTENDED `ImageTagHelper`, `LinkTagHelper`, and `ScriptTagHelper` to support automatic URL resolution from the current HTTP request when `TagHelperBaseUrlMode.Automatic` is configured
+
 Version: 10.6.0
 Availability: .NET 10 and .NET 9
 

--- a/.nuget/Cuemon.AspNetCore/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.AspNetCore/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10 and .NET 9
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10 and .NET 9
 

--- a/.nuget/Cuemon.Core.App/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Core.App/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Core/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Core/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Data.Integrity/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Data.Integrity/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Data.SqlClient/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Data.SqlClient/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Data/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Data/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Diagnostics/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Diagnostics/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Extensions.AspNetCore.Authentication/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.AspNetCore.Authentication/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10 and .NET 9
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10 and .NET 9
 

--- a/.nuget/Cuemon.Extensions.AspNetCore.Mvc.Formatters.Text.Json/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.AspNetCore.Mvc.Formatters.Text.Json/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10 and .NET 9
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10 and .NET 9
 

--- a/.nuget/Cuemon.Extensions.AspNetCore.Mvc.Formatters.Xml/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.AspNetCore.Mvc.Formatters.Xml/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10 and .NET 9
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10 and .NET 9
 

--- a/.nuget/Cuemon.Extensions.AspNetCore.Mvc.RazorPages/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.AspNetCore.Mvc.RazorPages/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10 and .NET 9
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10 and .NET 9
 

--- a/.nuget/Cuemon.Extensions.AspNetCore.Mvc/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.AspNetCore.Mvc/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10 and .NET 9
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10 and .NET 9
 

--- a/.nuget/Cuemon.Extensions.AspNetCore.Text.Json/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.AspNetCore.Text.Json/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10 and .NET 9
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10 and .NET 9
 

--- a/.nuget/Cuemon.Extensions.AspNetCore.Xml/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.AspNetCore.Xml/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10 and .NET 9
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10 and .NET 9
 

--- a/.nuget/Cuemon.Extensions.AspNetCore/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.AspNetCore/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10 and .NET 9
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10 and .NET 9
 

--- a/.nuget/Cuemon.Extensions.Collections.Generic/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Collections.Generic/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Extensions.Collections.Specialized/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Collections.Specialized/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Extensions.Core/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Core/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Extensions.Data.Integrity/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Data.Integrity/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Extensions.Data/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Data/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Extensions.DependencyInjection/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.DependencyInjection/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Extensions.Diagnostics/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Diagnostics/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Extensions.FileProviders.Physical/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.FileProviders.Physical/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Extensions.Hosting/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Hosting/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Extensions.IO/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.IO/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9, .NET Standard 2.1 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Extensions.Net/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Net/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Extensions.Reflection/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Reflection/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Extensions.Runtime.Caching/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Runtime.Caching/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Extensions.Text.Json/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Text.Json/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Extensions.Text/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Text/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Extensions.Threading/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Threading/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Extensions.Xml/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Xml/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.IO/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.IO/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Kernel/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Kernel/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Net/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Net/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Resilience/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Resilience/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Runtime.Caching/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Runtime.Caching/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Security.Cryptography/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Security.Cryptography/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Threading/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Threading/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/.nuget/Cuemon.Xml/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Xml/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version: 10.7.0
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 Version: 10.6.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 For more details, please refer to `PackageReleaseNotes.txt` on a per assembly basis in the `.nuget` folder.
 
+## [10.7.0] - 2026-08-11
+
+This is a minor release focused on enhancing Razor tag helper flexibility with automatic base URL resolution and modernizing package dependency management. The release introduces opt-in automatic base URL derivation from the current HTTP request while maintaining backward compatibility with the default configured mode. Tag helper functionality remains stable while new capabilities provide greater flexibility for dynamic deployment scenarios.
+
+### Added
+
+- `TagHelperBaseUrlMode` enumeration with `Configured` and `Automatic` modes to control base URL resolution strategy,
+- Automatic base URL resolution capability in tag helpers allowing dynamic derivation from the current HTTP request scheme, host, and path base when `BaseUrlMode` is set to `Automatic`,
+- `ViewContext` property injection in `CacheBustingTagHelper<TOptions>` base class to enable HTTP request context access for automatic URL resolution,
+- `ResolveUrl` protected method in tag helper base class for consistent URL path normalization and base URL composition,
+- Comprehensive test coverage for automatic base URL resolution across `AppImageTagHelper`, `AppLinkTagHelper`, and `AppScriptTagHelper` with test factory helper.
+
+### Changed
+
+- Central package transitive pinning enabled in `Directory.Packages.props` for improved transitive dependency resolution, requiring explicit declaration of transitive dependencies in affected projects,
+- Package dependencies updated to latest compatible versions across all supported target frameworks: Microsoft.Data.Sqlite (10.0.10 → 10.0.11, 9.0.18 → 9.0.19), Microsoft.Extensions packages (10.0.10 → 10.0.11, 9.0.18 → 9.0.19), System.Text.Json (10.0.10 → 10.0.11),
+- Newtonsoft.Json added as a conditional dependency for Cuemon.Core.Tests to explicitly manage transitive package resolution with transitive pinning enabled.
+
 ## [10.6.0] - 2026-08-07
 
 This is a minor release that combines new portable file provider and async retry capabilities with bug fixes for retry, timeout, cancellation, and exception-handling edge cases. Existing public APIs remain available, while the corrected failure and retry behavior may differ for affected edge cases. The release also includes comprehensive dependency updates across all supported target frameworks.
@@ -1856,6 +1874,7 @@ This release was primarily focused on adapting a more modern way of performing C
 - XmlWriterUtility class from Cuemon.Xml namespace
 - XmlWriterUtilityExtensions class from the Cuemon.Xml namespace
 
+[10.7.0]: https://github.com/codebeltnet/cuemon/compare/v10.6.0...v10.7.0
 [10.6.0]: https://github.com/codebeltnet/cuemon/compare/v10.5.5...v10.6.0
 [10.5.5]: https://github.com/codebeltnet/cuemon/compare/v10.5.4...v10.5.5
 [10.5.4]: https://github.com/codebeltnet/cuemon/compare/v10.5.3...v10.5.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 For more details, please refer to `PackageReleaseNotes.txt` on a per assembly basis in the `.nuget` folder.
 
-## [10.7.0] - 2026-08-11
+## [10.7.0] - 2026-08-12
 
 This is a minor release focused on enhancing Razor tag helper flexibility with automatic base URL resolution and modernizing package dependency management. The release introduces opt-in automatic base URL derivation from the current HTTP request while maintaining backward compatibility with the default configured mode. Tag helper functionality remains stable while new capabilities provide greater flexibility for dynamic deployment scenarios.
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <CentralPackageVersionManagement>true</CentralPackageVersionManagement>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
@@ -15,6 +15,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="MinVer" Version="7.0.0" />
     <PackageVersion Include="NativeLibraryLoader" Version="1.0.13" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" Condition="'$(MSBuildProjectName)' == 'Cuemon.Core.Tests'" />
     <PackageVersion Include="Xunit.v3.Priority" Version="1.1.18" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="coverlet.msbuild" Version="10.0.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageVersionManagement>true</CentralPackageVersionManagement>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
@@ -22,33 +23,33 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.11" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard2'))">
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.10" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.3" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.18" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.18" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="9.0.18" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.18" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.18" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.18" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.19" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.19" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="9.0.19" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.19" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.19" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.19" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net10')) OR $(TargetFramework.StartsWith('netstandard2'))">
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.11" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9')) OR $(TargetFramework.StartsWith('net10'))">
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.2" />

--- a/src/Cuemon.AspNetCore.Razor.TagHelpers/AppTagHelperOptions.cs
+++ b/src/Cuemon.AspNetCore.Razor.TagHelpers/AppTagHelperOptions.cs
@@ -19,6 +19,10 @@ public class AppTagHelperOptions : TagHelperOptions
     ///         <description><see cref="ProtocolUriScheme.Relative"/></description>
     ///     </item>
     ///     <item>
+    ///         <term><see cref="TagHelperOptions.BaseUrlMode"/></term>
+    ///         <description><see cref="TagHelperBaseUrlMode.Configured"/></description>
+    ///     </item>
+    ///     <item>
     ///         <term><see cref="TagHelperOptions.BaseUrl"/></term>
     ///         <description><c>null</c></description>
     ///     </item>

--- a/src/Cuemon.AspNetCore.Razor.TagHelpers/CacheBustingTagHelper.cs
+++ b/src/Cuemon.AspNetCore.Razor.TagHelpers/CacheBustingTagHelper.cs
@@ -1,6 +1,10 @@
-﻿using Cuemon.AspNetCore.Configuration;
+﻿using System;
+using System.Globalization;
+using Cuemon.AspNetCore.Configuration;
 using Cuemon.Configuration;
 using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Options;
 
 namespace Cuemon.AspNetCore.Razor.TagHelpers;
@@ -35,8 +39,35 @@ public abstract class CacheBustingTagHelper<TOptions> : TagHelper, IConfigurable
     protected bool UseCacheBusting => CacheBusting != null;
 
     /// <summary>
+    /// Gets or sets the current view context.
+    /// </summary>
+    /// <value>The current view context.</value>
+    [HtmlAttributeNotBound]
+    [ViewContext]
+    public ViewContext ViewContext { get; set; }
+
+    /// <summary>
     /// Gets the configured options of this instance.
     /// </summary>
     /// <value>The configured options of this instance.</value>
     public TOptions Options { get; }
+
+    /// <summary>
+    /// Resolves the fully qualified URL of the specified static resource.
+    /// </summary>
+    /// <param name="path">The relative path of the static resource.</param>
+    /// <returns>The fully qualified URL of the specified static resource.</returns>
+    protected string ResolveUrl(string path)
+    {
+        var baseUrl = Options.GetFormattedBaseUrl(ViewContext?.HttpContext?.Request);
+        var resolvedPath = NormalizePath(path, !string.IsNullOrWhiteSpace(baseUrl));
+        return string.Concat(baseUrl, UseCacheBusting ? string.Create(CultureInfo.InvariantCulture, $"{resolvedPath}?v={CacheBusting.Version}") : resolvedPath);
+    }
+
+    private static string NormalizePath(string path, bool normalize)
+    {
+        if (!normalize || string.IsNullOrWhiteSpace(path)) { return path; }
+        if (path.StartsWith("~/", StringComparison.Ordinal)) { path = path.Substring(2); }
+        return path.TrimStart('/');
+    }
 }

--- a/src/Cuemon.AspNetCore.Razor.TagHelpers/CdnTagHelperOptions.cs
+++ b/src/Cuemon.AspNetCore.Razor.TagHelpers/CdnTagHelperOptions.cs
@@ -19,6 +19,10 @@ public class CdnTagHelperOptions : TagHelperOptions
     ///         <description><see cref="ProtocolUriScheme.Relative"/></description>
     ///     </item>
     ///     <item>
+    ///         <term><see cref="TagHelperOptions.BaseUrlMode"/></term>
+    ///         <description><see cref="TagHelperBaseUrlMode.Configured"/></description>
+    ///     </item>
+    ///     <item>
     ///         <term><see cref="TagHelperOptions.BaseUrl"/></term>
     ///         <description><c>null</c></description>
     ///     </item>

--- a/src/Cuemon.AspNetCore.Razor.TagHelpers/ImageTagHelper.cs
+++ b/src/Cuemon.AspNetCore.Razor.TagHelpers/ImageTagHelper.cs
@@ -1,5 +1,4 @@
-﻿using System.Globalization;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Cuemon.AspNetCore.Configuration;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Options;
@@ -62,7 +61,7 @@ public abstract class ImageTagHelper<TOptions> : CacheBustingTagHelper<TOptions>
         output.TagName = "img";
         if (!string.IsNullOrWhiteSpace(Id)) { output.Attributes.Add("id", Id); }
         if (!string.IsNullOrWhiteSpace(Class)) { output.Attributes.Add("class", Class); }
-        output.Attributes.Add("src", string.Concat(Options.GetFormattedBaseUrl(), UseCacheBusting ? string.Create(CultureInfo.InvariantCulture, $"{Src}?v={CacheBusting.Version}") : Src));
+        output.Attributes.Add("src", ResolveUrl(Src));
         if (!string.IsNullOrWhiteSpace(Alt)) { output.Attributes.Add("alt", Alt); }
         if (!string.IsNullOrWhiteSpace(Title)) { output.Attributes.Add("title", Title); }
         return Task.CompletedTask;

--- a/src/Cuemon.AspNetCore.Razor.TagHelpers/LinkTagHelper.cs
+++ b/src/Cuemon.AspNetCore.Razor.TagHelpers/LinkTagHelper.cs
@@ -1,5 +1,4 @@
-﻿using System.Globalization;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Cuemon.AspNetCore.Configuration;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Razor.TagHelpers;
@@ -52,7 +51,7 @@ public abstract class LinkTagHelper<TOptions> : CacheBustingTagHelper<TOptions> 
         output.TagMode = TagMode.StartTagOnly;
         output.TagName = "link";
         output.Attributes.Add("rel", Rel);
-        output.Attributes.Add("href", string.Concat(Options.GetFormattedBaseUrl(), UseCacheBusting ? string.Create(CultureInfo.InvariantCulture, $"{Href}?v={CacheBusting.Version}") : Href));
+        output.Attributes.Add("href", ResolveUrl(Href));
         if (!string.IsNullOrWhiteSpace(Type)) { output.Attributes.Add("type", new HtmlString(Type)); }
         return Task.CompletedTask;
     }

--- a/src/Cuemon.AspNetCore.Razor.TagHelpers/ScriptTagHelper.cs
+++ b/src/Cuemon.AspNetCore.Razor.TagHelpers/ScriptTagHelper.cs
@@ -1,5 +1,4 @@
-﻿using System.Globalization;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Cuemon.AspNetCore.Configuration;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Options;
@@ -43,7 +42,7 @@ public abstract class ScriptTagHelper<TOptions> : CacheBustingTagHelper<TOptions
         output.TagMode = TagMode.StartTagAndEndTag;
         output.TagName = "script";
         output.Attributes.Add("type", "text/javascript");
-        output.Attributes.Add("src", string.Concat(Options.GetFormattedBaseUrl(), UseCacheBusting ? string.Create(CultureInfo.InvariantCulture, $"{Src}?v={CacheBusting.Version}") : Src));
+        output.Attributes.Add("src", ResolveUrl(Src));
         if (Defer) { output.Attributes.Add("defer", "defer"); }
         return Task.CompletedTask;
     }

--- a/src/Cuemon.AspNetCore.Razor.TagHelpers/TagHelperBaseUrlMode.cs
+++ b/src/Cuemon.AspNetCore.Razor.TagHelpers/TagHelperBaseUrlMode.cs
@@ -1,0 +1,15 @@
+namespace Cuemon.AspNetCore.Razor.TagHelpers;
+/// <summary>
+/// Specifies how the base URL of a static resource is resolved.
+/// </summary>
+public enum TagHelperBaseUrlMode
+{
+    /// <summary>
+    /// Specifies that the base URL is resolved exclusively from the configured values of <see cref="TagHelperOptions.BaseUrl"/> and <see cref="TagHelperOptions.Scheme"/>.
+    /// </summary>
+    Configured,
+    /// <summary>
+    /// Specifies that the base URL is resolved from the configured value of <see cref="TagHelperOptions.BaseUrl"/> when available; otherwise from the current HTTP request.
+    /// </summary>
+    Automatic
+}

--- a/src/Cuemon.AspNetCore.Razor.TagHelpers/TagHelperOptions.cs
+++ b/src/Cuemon.AspNetCore.Razor.TagHelpers/TagHelperOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Globalization;
 using Cuemon.Configuration;
 using Cuemon.Text;
+using Microsoft.AspNetCore.Http;
 
 namespace Cuemon.AspNetCore.Razor.TagHelpers;
 /// <summary>
@@ -9,10 +10,10 @@ namespace Cuemon.AspNetCore.Razor.TagHelpers;
 public abstract class TagHelperOptions : IParameterObject
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="CdnTagHelperOptions"/> class.
+    /// Initializes a new instance of the <see cref="TagHelperOptions"/> class.
     /// </summary>
     /// <remarks>
-    /// The following table shows the initial property values for an instance of <see cref="CdnTagHelperOptions"/>.
+    /// The following table shows the initial property values for an instance of <see cref="TagHelperOptions"/>.
     /// <list type="table">
     ///     <listheader>
     ///         <term>Property</term>
@@ -23,6 +24,10 @@ public abstract class TagHelperOptions : IParameterObject
     ///         <description><see cref="ProtocolUriScheme.Relative"/></description>
     ///     </item>
     ///     <item>
+    ///         <term><see cref="BaseUrlMode"/></term>
+    ///         <description><see cref="TagHelperBaseUrlMode.Configured"/></description>
+    ///     </item>
+    ///     <item>
     ///         <term><see cref="BaseUrl"/></term>
     ///         <description><c>null</c></description>
     ///     </item>
@@ -30,6 +35,7 @@ public abstract class TagHelperOptions : IParameterObject
     /// </remarks>
     protected TagHelperOptions()
     {
+        BaseUrlMode = TagHelperBaseUrlMode.Configured;
         Scheme = ProtocolUriScheme.Relative;
     }
 
@@ -38,6 +44,12 @@ public abstract class TagHelperOptions : IParameterObject
     /// </summary>
     /// <value>The <see cref="ProtocolUriScheme"/> of these options.</value>
     public ProtocolUriScheme Scheme { get; set; }
+
+    /// <summary>
+    /// Gets or sets the base URL resolution mode of these options.
+    /// </summary>
+    /// <value>The base URL resolution mode of these options.</value>
+    public TagHelperBaseUrlMode BaseUrlMode { get; set; }
 
     /// <summary>
     /// Gets or sets the base URL of these options.
@@ -51,20 +63,34 @@ public abstract class TagHelperOptions : IParameterObject
     /// <returns>The base URL of this instance, formatted according to the defined <see cref="Scheme"/>.</returns>
     public string GetFormattedBaseUrl()
     {
-        var baseUrlIsNullOrEmpty = string.IsNullOrWhiteSpace(BaseUrl);
+        if (string.IsNullOrWhiteSpace(BaseUrl)) { return ""; }
         var baseUrlWithForwardingSlash = new Stem(BaseUrl).AttachSuffix("/");
         switch (Scheme)
         {
             case ProtocolUriScheme.None:
-                return baseUrlIsNullOrEmpty ? "" : string.Create(CultureInfo.InvariantCulture, $"{baseUrlWithForwardingSlash}");
+                return string.Create(CultureInfo.InvariantCulture, $"{baseUrlWithForwardingSlash}");
             case ProtocolUriScheme.Http:
-                return baseUrlIsNullOrEmpty ? "" : string.Create(CultureInfo.InvariantCulture, $"{nameof(UriScheme.Http).ToLowerInvariant()}://{baseUrlWithForwardingSlash}");
+                return string.Create(CultureInfo.InvariantCulture, $"{nameof(UriScheme.Http).ToLowerInvariant()}://{baseUrlWithForwardingSlash}");
             case ProtocolUriScheme.Https:
-                return baseUrlIsNullOrEmpty ? "" : string.Create(CultureInfo.InvariantCulture, $"{nameof(UriScheme.Https).ToLowerInvariant()}://{baseUrlWithForwardingSlash}");
+                return string.Create(CultureInfo.InvariantCulture, $"{nameof(UriScheme.Https).ToLowerInvariant()}://{baseUrlWithForwardingSlash}");
             case ProtocolUriScheme.Relative:
-                return baseUrlIsNullOrEmpty ? "" : string.Create(CultureInfo.InvariantCulture, $"//{baseUrlWithForwardingSlash}");
+                return string.Create(CultureInfo.InvariantCulture, $"//{baseUrlWithForwardingSlash}");
             default:
                 return "";
         }
+    }
+
+    /// <summary>
+    /// Gets the base URL of this instance, resolved from the configured values of this instance or the specified <paramref name="request"/>.
+    /// </summary>
+    /// <param name="request">The current HTTP request that may provide the effective scheme, host and application base path when <see cref="BaseUrlMode"/> is <see cref="TagHelperBaseUrlMode.Automatic"/> and <see cref="BaseUrl"/> is not configured.</param>
+    /// <returns>The base URL of this instance, resolved from the configured values of this instance or the specified <paramref name="request"/>.</returns>
+    public string GetFormattedBaseUrl(HttpRequest request)
+    {
+        if (BaseUrlMode == TagHelperBaseUrlMode.Automatic && string.IsNullOrWhiteSpace(BaseUrl) && request != null)
+        {
+            return string.Create(CultureInfo.InvariantCulture, $"{request.Scheme}://{request.Host.ToUriComponent()}{request.PathBase.ToUriComponent()}/");
+        }
+        return GetFormattedBaseUrl();
     }
 }

--- a/test/Cuemon.AspNetCore.Razor.TagHelpers.Tests/AppImageTagHelperTest.cs
+++ b/test/Cuemon.AspNetCore.Razor.TagHelpers.Tests/AppImageTagHelperTest.cs
@@ -1,11 +1,6 @@
-﻿using System.Threading.Tasks;
-using Cuemon.AspNetCore.Razor.TagHelpers.Assets;
-using Cuemon.Extensions.AspNetCore.Configuration;
+﻿using System;
+using System.Threading.Tasks;
 using Codebelt.Extensions.Xunit;
-using Codebelt.Extensions.Xunit.Hosting.AspNetCore;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.TestHost;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Cuemon.AspNetCore.Razor.TagHelpers;
@@ -18,65 +13,34 @@ public class AppImageTagHelperTest : Test
     [Fact]
     public async Task Page_RenderImageTagForAppRole()
     {
-        using (var filter = WebHostTestFactory.Create(services =>
-        {
-            services.AddRazorPages();
-            services.Configure<CdnTagHelperOptions>(o =>
-            {
-                o.Scheme = ProtocolUriScheme.Https;
-                o.BaseUrl = "nblcdn.net";
-            });
-            services.Configure<AppTagHelperOptions>(o =>
-            {
-                o.Scheme = ProtocolUriScheme.Relative;
-                o.BaseUrl = "static.cuemon.net";
-            });
-        }, app =>
-               {
-                   app.UseRouting();
-                   app.UseEndpoints(endpoints => { endpoints.MapRazorPages(); });
-               }))
-        {
-            var client = filter.Host.GetTestClient();
-            var result = await client.GetAsync("/AppImageTagHelper");
-            var body = await result.Content.ReadAsStringAsync();
+        var body = await TagHelperTestFactory.GetBodyAsync("/AppImageTagHelper");
 
-            TestOutput.WriteLine(body);
+        TestOutput.WriteLine(body);
 
-            Assert.Equal(@"<img class=""hero-logo-image"" src=""//static.cuemon.net/cuemon-logo.svg"" alt=""Cuemon for .NET"">", body, ignoreLineEndingDifferences: true);
-        }
+        Assert.Equal(@"<img class=""hero-logo-image"" src=""//static.cuemon.net/cuemon-logo.svg"" alt=""Cuemon for .NET"">", body, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
     public async Task Page_RenderImageTagForAppRole_WithCacheBusting()
     {
-        using (var filter = WebHostTestFactory.Create(services =>
-        {
-            services.AddCacheBusting<FakeCacheBusting>();
-            services.AddRazorPages();
-            services.Configure<CdnTagHelperOptions>(o =>
-            {
-                o.Scheme = ProtocolUriScheme.Https;
-                o.BaseUrl = "nblcdn.net";
-            });
-            services.Configure<AppTagHelperOptions>(o =>
-            {
-                o.Scheme = ProtocolUriScheme.Relative;
-                o.BaseUrl = "static.cuemon.net";
-            });
-        }, app =>
-               {
-                   app.UseRouting();
-                   app.UseEndpoints(endpoints => { endpoints.MapRazorPages(); });
-               }))
-        {
-            var client = filter.Host.GetTestClient();
-            var result = await client.GetAsync("/AppImageTagHelper");
-            var body = await result.Content.ReadAsStringAsync();
+        var body = await TagHelperTestFactory.GetBodyAsync("/AppImageTagHelper", useCacheBusting: true);
 
-            TestOutput.WriteLine(body);
+        TestOutput.WriteLine(body);
 
-            Assert.Equal(@"<img class=""hero-logo-image"" src=""//static.cuemon.net/cuemon-logo.svg?v=00000000000000000000000000000000"" alt=""Cuemon for .NET"">", body, ignoreLineEndingDifferences: true);
-        }
+        Assert.Equal(@"<img class=""hero-logo-image"" src=""//static.cuemon.net/cuemon-logo.svg?v=00000000000000000000000000000000"" alt=""Cuemon for .NET"">", body, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public async Task Page_RenderImageTagForAppRole_UsingCurrentRequestOrigin()
+    {
+        var body = await TagHelperTestFactory.GetBodyAsync("/AppImageTagHelper?path=/images/logo.svg", o =>
+        {
+            o.BaseUrlMode = TagHelperBaseUrlMode.Automatic;
+            o.BaseUrl = null;
+        }, baseAddress: new Uri("https://localhost:7241"));
+
+        TestOutput.WriteLine(body);
+
+        Assert.Equal(@"<img class=""hero-logo-image"" src=""https://localhost:7241/images/logo.svg"" alt=""Cuemon for .NET"">", body, ignoreLineEndingDifferences: true);
     }
 }

--- a/test/Cuemon.AspNetCore.Razor.TagHelpers.Tests/AppLinkTagHelperTest.cs
+++ b/test/Cuemon.AspNetCore.Razor.TagHelpers.Tests/AppLinkTagHelperTest.cs
@@ -1,11 +1,6 @@
-﻿using System.Threading.Tasks;
-using Cuemon.AspNetCore.Razor.TagHelpers.Assets;
-using Cuemon.Extensions.AspNetCore.Configuration;
+﻿using System;
+using System.Threading.Tasks;
 using Codebelt.Extensions.Xunit;
-using Codebelt.Extensions.Xunit.Hosting.AspNetCore;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.TestHost;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Cuemon.AspNetCore.Razor.TagHelpers;
@@ -18,65 +13,89 @@ public class AppLinkTagHelperTest : Test
     [Fact]
     public async Task Page_RenderLinkTagForAppRole()
     {
-        using (var filter = WebHostTestFactory.Create(services =>
-        {
-            services.AddRazorPages();
-            services.Configure<CdnTagHelperOptions>(o =>
-            {
-                o.Scheme = ProtocolUriScheme.Https;
-                o.BaseUrl = "nblcdn.net";
-            });
-            services.Configure<AppTagHelperOptions>(o =>
-            {
-                o.Scheme = ProtocolUriScheme.Relative;
-                o.BaseUrl = "static.cuemon.net";
-            });
-        }, app =>
-               {
-                   app.UseRouting();
-                   app.UseEndpoints(endpoints => { endpoints.MapRazorPages(); });
-               }))
-        {
-            var client = filter.Host.GetTestClient();
-            var result = await client.GetAsync("/AppLinkTagHelper");
-            var body = await result.Content.ReadAsStringAsync();
+        var body = await TagHelperTestFactory.GetBodyAsync("/AppLinkTagHelper");
 
-            TestOutput.WriteLine(body);
+        TestOutput.WriteLine(body);
 
-            Assert.Equal(@"<link rel=""icon"" href=""//static.cuemon.net/favicon.svg"" type=""image/svg+xml"">", body, ignoreLineEndingDifferences: true);
-        }
+        Assert.Equal(@"<link rel=""icon"" href=""//static.cuemon.net/favicon.svg"" type=""image/svg+xml"">", body, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
     public async Task Page_RenderLinkTagForAppRole_WithCacheBusting()
     {
-        using (var filter = WebHostTestFactory.Create(services =>
-        {
-            services.AddCacheBusting<FakeCacheBusting>();
-            services.AddRazorPages();
-            services.Configure<CdnTagHelperOptions>(o =>
-            {
-                o.Scheme = ProtocolUriScheme.Https;
-                o.BaseUrl = "nblcdn.net";
-            });
-            services.Configure<AppTagHelperOptions>(o =>
-            {
-                o.Scheme = ProtocolUriScheme.Relative;
-                o.BaseUrl = "static.cuemon.net";
-            });
-        }, app =>
-               {
-                   app.UseRouting();
-                   app.UseEndpoints(endpoints => { endpoints.MapRazorPages(); });
-               }))
-        {
-            var client = filter.Host.GetTestClient();
-            var result = await client.GetAsync("/AppLinkTagHelper");
-            var body = await result.Content.ReadAsStringAsync();
+        var body = await TagHelperTestFactory.GetBodyAsync("/AppLinkTagHelper", useCacheBusting: true);
 
-            TestOutput.WriteLine(body);
+        TestOutput.WriteLine(body);
 
-            Assert.Equal(@"<link rel=""icon"" href=""//static.cuemon.net/favicon.svg?v=00000000000000000000000000000000"" type=""image/svg+xml"">", body, ignoreLineEndingDifferences: true);
-        }
+        Assert.Equal(@"<link rel=""icon"" href=""//static.cuemon.net/favicon.svg?v=00000000000000000000000000000000"" type=""image/svg+xml"">", body, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public async Task Page_RenderLinkTagForAppRole_WithoutConfiguredBaseUrl()
+    {
+        var body = await TagHelperTestFactory.GetBodyAsync("/AppLinkTagHelper?variant=stylesheet&path=/css/site.css", o => o.BaseUrl = null);
+
+        TestOutput.WriteLine(body);
+
+        Assert.Equal(@"<link rel=""stylesheet"" href=""/css/site.css"" type=""text/css"">", body, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public async Task Page_RenderLinkTagForAppRole_UsingCurrentRequestOrigin()
+    {
+        var body = await TagHelperTestFactory.GetBodyAsync("/AppLinkTagHelper?variant=stylesheet&path=css/site.css", o =>
+        {
+            o.BaseUrlMode = TagHelperBaseUrlMode.Automatic;
+            o.BaseUrl = null;
+            o.Scheme = ProtocolUriScheme.Http;
+        }, baseAddress: new Uri("https://localhost:7241"));
+
+        TestOutput.WriteLine(body);
+
+        Assert.Equal(@"<link rel=""stylesheet"" href=""https://localhost:7241/css/site.css"" type=""text/css"">", body, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public async Task Page_RenderLinkTagForAppRole_UsingExplicitBaseUrlWhenAutomaticModeIsEnabled()
+    {
+        var body = await TagHelperTestFactory.GetBodyAsync("/AppLinkTagHelper?variant=stylesheet&path=/css/site.css", o =>
+        {
+            o.BaseUrlMode = TagHelperBaseUrlMode.Automatic;
+            o.BaseUrl = "assets.example.com";
+            o.Scheme = ProtocolUriScheme.Https;
+        }, baseAddress: new Uri("http://localhost:7241"));
+
+        TestOutput.WriteLine(body);
+
+        Assert.Equal(@"<link rel=""stylesheet"" href=""https://assets.example.com/css/site.css"" type=""text/css"">", body, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public async Task Page_RenderLinkTagForAppRole_PreservesFontPreloadAttributes()
+    {
+        var body = await TagHelperTestFactory.GetBodyAsync("/AppLinkTagHelper?variant=preload");
+
+        TestOutput.WriteLine(body);
+
+        Assert.Contains(@"<link", body);
+        Assert.Contains(@"rel=""preload""", body);
+        Assert.Contains(@"href=""//static.cuemon.net/fonts/antonio-latin.woff2""", body);
+        Assert.Contains(@"as=""font""", body);
+        Assert.Contains(@"type=""font/woff2""", body);
+        Assert.Contains("crossorigin", body);
+    }
+
+    [Fact]
+    public async Task Page_RenderLinkTagForAppRole_PreservesMaskIconAttributes()
+    {
+        var body = await TagHelperTestFactory.GetBodyAsync("/AppLinkTagHelper?variant=mask-icon");
+
+        TestOutput.WriteLine(body);
+
+        Assert.Contains(@"<link", body);
+        Assert.Contains(@"rel=""mask-icon""", body);
+        Assert.Contains(@"href=""//static.cuemon.net/mask-icon.svg""", body);
+        Assert.Contains(@"type=""image/svg+xml""", body);
+        Assert.Contains(@"color=""#000000""", body);
     }
 }

--- a/test/Cuemon.AspNetCore.Razor.TagHelpers.Tests/AppScriptTagHelperTest.cs
+++ b/test/Cuemon.AspNetCore.Razor.TagHelpers.Tests/AppScriptTagHelperTest.cs
@@ -1,11 +1,6 @@
-﻿using System.Threading.Tasks;
-using Cuemon.AspNetCore.Razor.TagHelpers.Assets;
-using Cuemon.Extensions.AspNetCore.Configuration;
+﻿using System;
+using System.Threading.Tasks;
 using Codebelt.Extensions.Xunit;
-using Codebelt.Extensions.Xunit.Hosting.AspNetCore;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.TestHost;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Cuemon.AspNetCore.Razor.TagHelpers;
@@ -18,65 +13,63 @@ public class AppScriptTagHelperTest : Test
     [Fact]
     public async Task Page_RenderScriptTagForAppRole()
     {
-        using (var filter = WebHostTestFactory.Create(services =>
-        {
-            services.AddRazorPages();
-            services.Configure<CdnTagHelperOptions>(o =>
-            {
-                o.Scheme = ProtocolUriScheme.Https;
-                o.BaseUrl = "nblcdn.net";
-            });
-            services.Configure<AppTagHelperOptions>(o =>
-            {
-                o.Scheme = ProtocolUriScheme.Relative;
-                o.BaseUrl = "static.cuemon.net";
-            });
-        }, app =>
-               {
-                   app.UseRouting();
-                   app.UseEndpoints(endpoints => { endpoints.MapRazorPages(); });
-               }))
-        {
-            var client = filter.Host.GetTestClient();
-            var result = await client.GetAsync("/AppScriptTagHelper");
-            var body = await result.Content.ReadAsStringAsync();
+        var body = await TagHelperTestFactory.GetBodyAsync("/AppScriptTagHelper");
 
-            TestOutput.WriteLine(body);
+        TestOutput.WriteLine(body);
 
-            Assert.Equal(@"<script type=""text/javascript"" src=""//static.cuemon.net/js/site.js""></script>", body, ignoreLineEndingDifferences: true);
-        }
+        Assert.Equal(@"<script type=""text/javascript"" src=""//static.cuemon.net/js/site.js""></script>", body, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
     public async Task Page_RenderScriptTagForAppRole_WithCacheBusting()
     {
-        using (var filter = WebHostTestFactory.Create(services =>
-        {
-            services.AddCacheBusting<FakeCacheBusting>();
-            services.AddRazorPages();
-            services.Configure<CdnTagHelperOptions>(o =>
-            {
-                o.Scheme = ProtocolUriScheme.Https;
-                o.BaseUrl = "nblcdn.net";
-            });
-            services.Configure<AppTagHelperOptions>(o =>
-            {
-                o.Scheme = ProtocolUriScheme.Relative;
-                o.BaseUrl = "static.cuemon.net";
-            });
-        }, app =>
-               {
-                   app.UseRouting();
-                   app.UseEndpoints(endpoints => { endpoints.MapRazorPages(); });
-               }))
-        {
-            var client = filter.Host.GetTestClient();
-            var result = await client.GetAsync("/AppScriptTagHelper");
-            var body = await result.Content.ReadAsStringAsync();
+        var body = await TagHelperTestFactory.GetBodyAsync("/AppScriptTagHelper", useCacheBusting: true);
 
-            TestOutput.WriteLine(body);
+        TestOutput.WriteLine(body);
 
-            Assert.Equal(@"<script type=""text/javascript"" src=""//static.cuemon.net/js/site.js?v=00000000000000000000000000000000""></script>", body, ignoreLineEndingDifferences: true);
-        }
+        Assert.Equal(@"<script type=""text/javascript"" src=""//static.cuemon.net/js/site.js?v=00000000000000000000000000000000""></script>", body, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public async Task Page_RenderScriptTagForAppRole_UsingCurrentRequestOrigin()
+    {
+        var body = await TagHelperTestFactory.GetBodyAsync("/AppScriptTagHelper", o =>
+        {
+            o.BaseUrlMode = TagHelperBaseUrlMode.Automatic;
+            o.BaseUrl = null;
+        }, baseAddress: new Uri("https://localhost:7241"));
+
+        TestOutput.WriteLine(body);
+
+        Assert.Equal(@"<script type=""text/javascript"" src=""https://localhost:7241/js/site.js""></script>", body, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public async Task Page_RenderScriptTagForAppRole_UsingCurrentRequestOriginAndPathBase_WithCacheBusting()
+    {
+        var body = await TagHelperTestFactory.GetBodyAsync("/myapp/AppScriptTagHelper?path=~/js/site.js", o =>
+        {
+            o.BaseUrlMode = TagHelperBaseUrlMode.Automatic;
+            o.BaseUrl = null;
+        }, useCacheBusting: true, baseAddress: new Uri("https://example.com"), pathBase: "/myapp");
+
+        TestOutput.WriteLine(body);
+
+        Assert.Equal(@"<script type=""text/javascript"" src=""https://example.com/myapp/js/site.js?v=00000000000000000000000000000000""></script>", body, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public async Task Page_RenderScriptTagForAppRole_UsingLocalHttpExternalOriginWhenConfigured()
+    {
+        var body = await TagHelperTestFactory.GetBodyAsync("/AppScriptTagHelper?path=~/js/site.js", o =>
+        {
+            o.BaseUrlMode = TagHelperBaseUrlMode.Automatic;
+            o.BaseUrl = "localhost:8080";
+            o.Scheme = ProtocolUriScheme.Http;
+        }, baseAddress: new Uri("https://localhost:7241"));
+
+        TestOutput.WriteLine(body);
+
+        Assert.Equal(@"<script type=""text/javascript"" src=""http://localhost:8080/js/site.js""></script>", body, ignoreLineEndingDifferences: true);
     }
 }

--- a/test/Cuemon.AspNetCore.Razor.TagHelpers.Tests/Pages/AppImageTagHelper.cshtml
+++ b/test/Cuemon.AspNetCore.Razor.TagHelpers.Tests/Pages/AppImageTagHelper.cshtml
@@ -1,2 +1,6 @@
 ﻿@page
-<app-img class="hero-logo-image" src="cuemon-logo.svg" alt="Cuemon for .NET" />
+@{
+    var src = Request.Query["path"].ToString();
+    if (string.IsNullOrWhiteSpace(src)) { src = "cuemon-logo.svg"; }
+}
+<app-img class="hero-logo-image" src="@src" alt="Cuemon for .NET" />

--- a/test/Cuemon.AspNetCore.Razor.TagHelpers.Tests/Pages/AppLinkTagHelper.cshtml
+++ b/test/Cuemon.AspNetCore.Razor.TagHelpers.Tests/Pages/AppLinkTagHelper.cshtml
@@ -1,2 +1,40 @@
 ﻿@page
-<app-link rel="icon" href="favicon.svg" type="image/svg+xml" />
+@{
+    var variant = Request.Query["variant"].ToString();
+    var href = Request.Query["path"].ToString();
+    if (string.IsNullOrWhiteSpace(href))
+    {
+        if (variant == "preload")
+        {
+            href = "fonts/antonio-latin.woff2";
+        }
+        else if (variant == "mask-icon")
+        {
+            href = "mask-icon.svg";
+        }
+        else if (variant == "stylesheet")
+        {
+            href = "css/site.css";
+        }
+        else
+        {
+            href = "favicon.svg";
+        }
+    }
+}
+@if (variant == "preload")
+{
+    <app-link rel="preload" href="@href" as="font" type="font/woff2" crossorigin />
+}
+else if (variant == "mask-icon")
+{
+    <app-link rel="mask-icon" href="@href" type="image/svg+xml" color="#000000" />
+}
+else if (variant == "stylesheet")
+{
+    <app-link href="@href" />
+}
+else
+{
+    <app-link rel="icon" href="@href" type="image/svg+xml" />
+}

--- a/test/Cuemon.AspNetCore.Razor.TagHelpers.Tests/Pages/AppScriptTagHelper.cshtml
+++ b/test/Cuemon.AspNetCore.Razor.TagHelpers.Tests/Pages/AppScriptTagHelper.cshtml
@@ -1,2 +1,6 @@
 ﻿@page
-<app-script src="js/site.js" />
+@{
+    var src = Request.Query["path"].ToString();
+    if (string.IsNullOrWhiteSpace(src)) { src = "js/site.js"; }
+}
+<app-script src="@src" />

--- a/test/Cuemon.AspNetCore.Razor.TagHelpers.Tests/TagHelperTestFactory.cs
+++ b/test/Cuemon.AspNetCore.Razor.TagHelpers.Tests/TagHelperTestFactory.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Threading.Tasks;
+using Cuemon.AspNetCore.Razor.TagHelpers.Assets;
+using Cuemon.Extensions.AspNetCore.Configuration;
+using Codebelt.Extensions.Xunit.Hosting.AspNetCore;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cuemon.AspNetCore.Razor.TagHelpers;
+internal static class TagHelperTestFactory
+{
+    internal static async Task<string> GetBodyAsync(string requestUri, Action<AppTagHelperOptions> appSetup = null, Action<CdnTagHelperOptions> cdnSetup = null, bool useCacheBusting = false, Uri baseAddress = null, string pathBase = null)
+    {
+        using var filter = WebHostTestFactory.Create(services =>
+        {
+            if (useCacheBusting) { services.AddCacheBusting<FakeCacheBusting>(); }
+            services.AddRazorPages();
+            services.Configure<CdnTagHelperOptions>(o =>
+            {
+                o.Scheme = ProtocolUriScheme.Https;
+                o.BaseUrl = "nblcdn.net";
+                cdnSetup?.Invoke(o);
+            });
+            services.Configure<AppTagHelperOptions>(o =>
+            {
+                o.Scheme = ProtocolUriScheme.Relative;
+                o.BaseUrl = "static.cuemon.net";
+                appSetup?.Invoke(o);
+            });
+        }, app =>
+        {
+            if (!string.IsNullOrWhiteSpace(pathBase)) { app.UsePathBase(pathBase); }
+            app.UseRouting();
+            app.UseEndpoints(endpoints => { endpoints.MapRazorPages(); });
+        });
+
+        var client = filter.Host.GetTestClient();
+        if (baseAddress != null) { client.BaseAddress = baseAddress; }
+
+        var result = await client.GetAsync(requestUri);
+        return (await result.Content.ReadAsStringAsync()).Trim();
+    }
+}

--- a/test/Cuemon.Core.Tests/Threading/AwaiterTest.cs
+++ b/test/Cuemon.Core.Tests/Threading/AwaiterTest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Codebelt.Extensions.Xunit;
@@ -459,8 +458,9 @@ public class AwaiterTest : Test
     [Fact]
     public async Task RunUntilSuccessfulOrTimeoutAsync_ShouldCapDelayToRemainingTimeoutWindow()
     {
-        var stopwatch = Stopwatch.StartNew();
         var callCount = 0;
+        using var cancellationSource = new CancellationTokenSource();
+        cancellationSource.CancelAfter(TimeSpan.FromSeconds(2));
 
         Task<ConditionalValue> Method()
         {
@@ -468,14 +468,11 @@ public class AwaiterTest : Test
             return Task.FromResult<ConditionalValue>(new UnsuccessfulValue());
         }
 
-        var result = await Run(Method, TimeSpan.FromMilliseconds(40), TimeSpan.FromMilliseconds(200));
-
-        stopwatch.Stop();
+        var result = await Run(Method, TimeSpan.FromMilliseconds(40), TimeSpan.FromSeconds(5), cancellationToken: cancellationSource.Token);
 
         Assert.False(result.Succeeded);
         Assert.Null(result.Failure);
         Assert.Equal(1, callCount);
-        Assert.True(stopwatch.Elapsed < TimeSpan.FromMilliseconds(150), $"Expected capped delay, but elapsed was {stopwatch.Elapsed}.");
     }
 
     [Fact]

--- a/test/Cuemon.Data.Tests/Assets/SqliteDatabase.cs
+++ b/test/Cuemon.Data.Tests/Assets/SqliteDatabase.cs
@@ -77,8 +77,8 @@ internal static class SqliteDatabase
                                                             ,[ModifiedDate])
                                                             VALUES
                                                             ({{reader.GetInt32(0)}},
-                                                            "{{reader.GetString(1)}}",
-                                                            "{{reader.GetString(2)}}",
+                                                            {{StringOrNull(reader.GetString(1))}},
+                                                            {{StringOrNull(reader.GetString(2))}},
                                                             {{reader.GetInt32(3)}},
                                                             {{reader.GetInt32(4)}},
                                                             {{StringOrNull(reader.GetString(5))}},
@@ -96,11 +96,11 @@ internal static class SqliteDatabase
                                                             {{StringOrNull(reader.GetString(17))}},
                                                             {{(reader.GetString(18) == "NULL" ? "NULL" : reader.GetInt32(18))}},
                                                             {{(reader.GetString(19) == "NULL" ? "NULL" : reader.GetInt32(19))}},
-                                                            "{{reader.GetDateTime(20):O}}",
-                                                            {{(reader.GetString(21) == "NULL" ? "NULL" : string.Concat("\"", reader.GetDateTime(21).ToString("O"), "\""))}},
-                                                            {{(reader.GetString(22) == "NULL" ? "NULL" : string.Concat("\"", reader.GetDateTime(22).ToString("O"), "\""))}},
-                                                            "{{reader.GetString(23)}}",
-                                                            "{{reader.GetDateTime(24):O}}")
+                                                            {{StringOrNull(reader.GetDateTime(20).ToString("O", CultureInfo.InvariantCulture))}},
+                                                            {{(reader.GetString(21) == "NULL" ? "NULL" : StringOrNull(reader.GetDateTime(21).ToString("O", CultureInfo.InvariantCulture)))}},
+                                                            {{(reader.GetString(22) == "NULL" ? "NULL" : StringOrNull(reader.GetDateTime(22).ToString("O", CultureInfo.InvariantCulture)))}},
+                                                            {{StringOrNull(reader.GetString(23))}},
+                                                            {{StringOrNull(reader.GetDateTime(24).ToString("O", CultureInfo.InvariantCulture))}})
                                                             """);
 
             try
@@ -118,6 +118,7 @@ internal static class SqliteDatabase
     private static string StringOrNull(string value)
     {
         if (value == "NULL") { return "NULL"; }
-        return (value.StartsWith("\"") && value.EndsWith("\"")) ? $"{value}" : $"\"{value}\"";
+        if (value.Length >= 2 && value.StartsWith("\"") && value.EndsWith("\"")) { value = value.Substring(1, value.Length - 2); }
+        return $"'{value.Replace("'", "''")}'";
     }
 }

--- a/test/Cuemon.Kernel.Tests/Threading/AwaiterTest.cs
+++ b/test/Cuemon.Kernel.Tests/Threading/AwaiterTest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Codebelt.Extensions.Xunit;
@@ -192,22 +191,15 @@ public class AwaiterTest : Test
     [Fact]
     public async Task RunUntilSuccessfulOrTimeoutAsync_ShouldReturnDefaultUnsuccessful_WhenRepeatedResultsRemainUnsuccessfulUntilTimeout()
     {
-        var callCount = 0;
-
         Task<ConditionalValue> Method()
         {
-            callCount++;
             return Task.FromResult<ConditionalValue>(new UnsuccessfulValue());
         }
 
-        var result = await Run(Method, TimeSpan.FromMilliseconds(80), RetryDelay);
+        var unsuccessful = Assert.IsType<UnsuccessfulValue>(await Run(Method, TimeSpan.FromMilliseconds(80), RetryDelay));
 
-        TestOutput.WriteLine("Call-count: " + callCount);
-
-        Assert.IsType<UnsuccessfulValue>(result);
-        Assert.False(result.Succeeded);
-        Assert.Null(result.Failure);
-        Assert.True(callCount >= 2);
+        Assert.False(unsuccessful.Succeeded);
+        Assert.Null(unsuccessful.Failure);
     }
 
     [Fact]
@@ -466,8 +458,9 @@ public class AwaiterTest : Test
     [Fact]
     public async Task RunUntilSuccessfulOrTimeoutAsync_ShouldCapDelayToRemainingTimeoutWindow()
     {
-        var stopwatch = Stopwatch.StartNew();
         var callCount = 0;
+        using var cancellationSource = new CancellationTokenSource();
+        cancellationSource.CancelAfter(TimeSpan.FromSeconds(2));
 
         Task<ConditionalValue> Method()
         {
@@ -475,14 +468,11 @@ public class AwaiterTest : Test
             return Task.FromResult<ConditionalValue>(new UnsuccessfulValue());
         }
 
-        var result = await Run(Method, TimeSpan.FromMilliseconds(40), TimeSpan.FromMilliseconds(200));
-
-        stopwatch.Stop();
+        var result = await Run(Method, TimeSpan.FromMilliseconds(40), TimeSpan.FromSeconds(5), cancellationToken: cancellationSource.Token);
 
         Assert.False(result.Succeeded);
         Assert.Null(result.Failure);
         Assert.Equal(1, callCount);
-        Assert.True(stopwatch.Elapsed < TimeSpan.FromMilliseconds(150), $"Expected capped delay, but elapsed was {stopwatch.Elapsed}.");
     }
 
     [Fact]


### PR DESCRIPTION
This pull request updates the release notes for multiple NuGet packages in the Cuemon library to announce version 10.7.0. The primary focus is on upgrading dependencies to their latest compatible versions across all supported target frameworks. Additionally, the `Cuemon.AspNetCore.Razor.TagHelpers` package introduces several new features and enhancements related to tag helper URL resolution.

**Dependency Upgrades**

* All listed packages have had their dependencies upgraded to the latest compatible versions for all supported target frameworks, including .NET 10, .NET 9, and .NET Standard 2.0 where applicable. This is reflected in the release notes for each package. [[1]](diffhunk://#diff-c39ba600c1a0c1d15c78d996e408e4e19543cc08bf1fa9f87b21b104325d0ce6R1-R6) [[2]](diffhunk://#diff-33552699ee225fb4d6a0b5b7c74b15075137c4e7595f30ebb5f4e7aca2a1a734R1-R6) [[3]](diffhunk://#diff-5008d0251870c2bd4630fd6c2d8e9ee8caefc784f4e2e843c9114b4e5ddfb74dR1-R6) [[4]](diffhunk://#diff-dc336ee2d0f98b69176806c2329259b920b81536fb1939055cb787f85b9861baR1-R6) [[5]](diffhunk://#diff-b593084df52362edff73eb7647eb4447d286a35dca1a5a37a61e011c33192b2cR1-R6) [[6]](diffhunk://#diff-feb040adcf7b111053894f08adeacd5983e97f41bf09fda14f75596f0cfd164eR1-R6) [[7]](diffhunk://#diff-ab0b535dfd0c6ba321e5bfbcab3ab5f8f5943f4c216fdf0f56d128291aa4ccefR1-R6) [[8]](diffhunk://#diff-30ba642f105d9f35bba22ae6352e838aa678efb57cf77bcc70ee4bfdb0b41fe7R1-R6) [[9]](diffhunk://#diff-7ef2cf28f4dfaac02d1e92d65b00198c885176e2e4821556ce66690c6ed2521fR1-R6) [[10]](diffhunk://#diff-1e02ec80942a6c43b840e297b8da28c305b9fadaf60715def46220cdfd5ba0e9R1-R6) [[11]](diffhunk://#diff-299bdd6f4b27e35a3ecc42ccdd402948a5c0de641d006675f9eecf8354438e8aR1-R6) [[12]](diffhunk://#diff-d725821a6ec40102da98820f4a1c354b679f716573a320095c58066b3a3c56f6R1-R6) [[13]](diffhunk://#diff-b5a0ec98c42bdef671bed7122950074898eadb956e9e43e21fa6b1f9771f4a2bR1-R6) [[14]](diffhunk://#diff-014b57b95925e894eda7beee19278c7ff6cd6922b5744ad0fc381f6c2a29ec24R1-R6) [[15]](diffhunk://#diff-c40b251ae8a7daa71d4cd3e7feceb784e2c83dda5bce2c2299c714b71c3f613fR1-R6) [[16]](diffhunk://#diff-b7eb705ffc989084c6d1f7a2fa186aaa67c211ad7a19fe3a8b7575089bfe9e92R1-R6)

**New Features and Enhancements in Razor Tag Helpers**

* Added `TagHelperBaseUrlMode` enum to control how base URLs are resolved in tag helper options.
* Introduced automatic base URL resolution to `CacheBustingTagHelper` via the new `ResolveUrl` method.
* Added `ViewContext` property to `CacheBustingTagHelper` for access to the current HTTP request context.
* Extended `ImageTagHelper`, `LinkTagHelper`, and `ScriptTagHelper` to support automatic URL resolution from the current HTTP request when `TagHelperBaseUrlMode.Automatic` is configured.